### PR TITLE
Fix validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: griddleR
 Title: Grid-based Simulation Parameter Inputs
-Version: 0.1.1
+Version: 0.1.2
 Authors@R:
     person("Scott", "Olesen", , "ulp7@cdc.gov", role = c("aut", "cre"))
 Description: This package contains tools for common parameters of

--- a/R/read_griddle.R
+++ b/R/read_griddle.R
@@ -159,17 +159,6 @@ validate_griddle <- function(griddle) {
   TRUE
 }
 
-validate_parameter_sets <- function(parameter_sets) {
-  # all parameter sets must be lists
-  stopifnot(all(purrr::map_lgl(parameter_sets, function(x) class(x) == "list")))
-
-  # all parameter sets must have the same names
-  names_list <- purrr::map(parameter_sets, names)
-  stopifnot(all(
-    purrr::map_lgl(names_list, function(x) identical(x, names_list[[1]]))
-  ))
-}
-
 #' Either is an integer, or equal to its integer cast
 #'
 #' @param x value

--- a/R/read_griddle.R
+++ b/R/read_griddle.R
@@ -47,6 +47,8 @@ parse_griddle <- function(griddle) {
     }
   }
 
+  validate_parameter_sets(parameter_sets)
+
   parameter_sets
 }
 
@@ -152,26 +154,20 @@ validate_griddle <- function(griddle) {
       # every nest must have at least one name that appears in the grid
       stopifnot(length(intersect(names(nest), grid_names)) >= 1)
     }
-
-    # nested names must (1) in every nest or one of (2A) in the grid or
-    # (2B) in the baseline
-    for (nm in nested_names) {
-      in_grid <- nm %in% grid_names
-      in_baseline <- has_baseline && (nm %in% baseline_names)
-      in_all_nests <- all(purrr::map_lgl(
-        nested_names_by_nest,
-        function(nms) nm %in% nms
-      ))
-      if (in_grid && in_baseline) {
-        stop(glue::glue("Parameter `{nm}` in grid and baseline"))
-      }
-      if (!(in_grid || in_baseline) && !in_all_nests) {
-        stop(glue::glue("Parameter `{nm}` not in grid, baseline, or all nests"))
-      }
-    }
   }
 
   TRUE
+}
+
+validate_parameter_sets <- function(parameter_sets) {
+  # all parameter sets must be lists
+  stopifnot(all(purrr::map_lgl(parameter_sets, function(x) class(x) == "list")))
+
+  # all parameter sets must have the same names
+  names_list <- purrr::map(parameter_sets, names)
+  stopifnot(all(
+    purrr::map_lgl(names_list, function(x) identical(x, names_list[[1]]))
+  ))
 }
 
 #' Either is an integer, or equal to its integer cast

--- a/R/read_parameter_sets.R
+++ b/R/read_parameter_sets.R
@@ -21,4 +21,10 @@ validate_parameter_sets <- function(parameter_sets) {
       stop("Parameter set must be named")
     }
   }
+
+  # all parameter sets must have the same names
+  names_list <- purrr::map(parameter_sets, names)
+  stopifnot(all(
+    purrr::map_lgl(names_list, function(x) identical(x, names_list[[1]]))
+  ))
 }

--- a/tests/testthat/data/nest_missing.yaml
+++ b/tests/testthat/data/nest_missing.yaml
@@ -1,0 +1,6 @@
+grid_parameters:
+  vaccine_scenario: [baseline, optimistic]
+nested_parameters:
+  - vaccine_scenario: baseline
+    vaccine_amount: 100
+  # note that there should be a specification of optimistic vaccine amount here

--- a/tests/testthat/data/nest_only.yaml
+++ b/tests/testthat/data/nest_only.yaml
@@ -1,6 +1,6 @@
 grid_parameters:
-  vaccine_scenario: baseline, optimistic
-  intervention_scenario: baseline, optimistic
+  vaccine_scenario: [baseline, optimistic]
+  intervention_scenario: [baseline, optimistic]
 nested_parameters:
   - vaccine_scenario: baseline
     vaccine_amount: 100

--- a/tests/testthat/data/nest_only.yaml
+++ b/tests/testthat/data/nest_only.yaml
@@ -1,0 +1,12 @@
+grid_parameters:
+  vaccine_scenario: baseline, optimistic
+  intervention_scenario: baseline, optimistic
+nested_parameters:
+  - vaccine_scenario: baseline
+    vaccine_amount: 100
+  - vaccine_scenario: optimistic
+    vaccine_amount: 200
+  - intervention_scenario: baseline
+    intervention_efficacy: 0.3
+  - intervention_scenario: optimistic
+    intervention_efficacy: 0.8

--- a/tests/testthat/test_read_griddle.R
+++ b/tests/testthat/test_read_griddle.R
@@ -88,19 +88,19 @@ test_griddle(
 
 test_griddle("nest_only", list(
   list(
-    vaccine_scenario = "baseline", vaccine_amount = 100,
-    intervention_scenario = "baseline", intervention_efficacy = 0.3
+    vaccine_scenario = "baseline", intervention_scenario = "baseline",
+    vaccine_amount = 100, intervention_efficacy = 0.3
   ),
   list(
-    vaccine_scenario = "baseline", vaccine_amount = 100,
-    intervention_scenario = "optimistic", intervention_efficacy = 0.8
+    vaccine_scenario = "baseline", intervention_scenario = "optimistic",
+    vaccine_amount = 100, intervention_efficacy = 0.8
   ),
   list(
-    vaccine_scenario = "optimistic", vaccine_amount = 200,
-    intervention_scenario = "baseline", intervention_efficacy = 0.3
+    vaccine_scenario = "optimistic", intervention_scenario = "baseline",
+    vaccine_amount = 200, intervention_efficacy = 0.3
   ),
   list(
-    vaccine_scenario = "optimistic", vaccine_amount = 200,
-    intervention_scenario = "optimistic", intervention_efficacy = 0.8
+    vaccine_scenario = "optimistic", intervention_scenario = "optimistic",
+    vaccine_amount = 200, intervention_efficacy = 0.8
   )
 ))

--- a/tests/testthat/test_read_griddle.R
+++ b/tests/testthat/test_read_griddle.R
@@ -85,3 +85,22 @@ test_griddle(
     )
   )
 )
+
+test_griddle("nest_only", list(
+  list(
+    vaccine_scenario = "baseline", vaccine_amount = 100,
+    intervention_scenario = "baseline", intervention_efficacy = 0.3
+  ),
+  list(
+    vaccine_scenario = "baseline", vaccine_amount = 100,
+    intervention_scenario = "optimistic", intervention_efficacy = 0.8
+  ),
+  list(
+    vaccine_scenario = "optimistic", vaccine_amount = 200,
+    intervention_scenario = "baseline", intervention_efficacy = 0.3
+  ),
+  list(
+    vaccine_scenario = "optimistic", vaccine_amount = 200,
+    intervention_scenario = "optimistic", intervention_efficacy = 0.8
+  )
+))

--- a/tests/testthat/test_read_griddle.R
+++ b/tests/testthat/test_read_griddle.R
@@ -104,3 +104,9 @@ test_griddle("nest_only", list(
     vaccine_amount = 200, intervention_efficacy = 0.8
   )
 ))
+
+test_that("missing nests fail", {
+  expect_error({
+    read_griddle(test_path("data", "nest_missing.yaml"))
+  })
+})


### PR DESCRIPTION
Previously, validation expected that a parameter name would appear in the baseline, the grid, or in every nest. This is not necessary. For example:

```yaml
grid_parameters:
  scenario: [A, B]
  location: [TX, CA]

nested_parameters:
  - scenario: A
    R0: 1.0
  - scenario: B
    R0: 1.5
  - location: TX
    weather: steamy
  - location: CA
    weather: chilly
```

Note that `R0` and `weather` don't appear in every nest, but they will appear in every output parameter set.

Instead, do a validation on the parameter sets after they are produced by `read_griddle()`.